### PR TITLE
 Allow tallies with zero scores to be ignored for tally precision triggers

### DIFF
--- a/docs/source/io_formats/tallies.rst
+++ b/docs/source/io_formats/tallies.rst
@@ -100,6 +100,13 @@ The ``<tally>`` element accepts the following sub-elements:
 
      *Default*: None
 
+   :allow_zero:
+     Whether to allow zero tally bins to be ignored when assessing the
+     convergece of the precision trigger. If True, only nonzero tally scores
+     will be compared to the trigger's threshold.
+
+     *Default*: False
+
    :scores:
      The score(s) in this tally to which the trigger should be applied.
 

--- a/include/openmc/tallies/trigger.h
+++ b/include/openmc/tallies/trigger.h
@@ -23,6 +23,7 @@ enum class TriggerMetric {
 struct Trigger {
   TriggerMetric metric; //!< The type of uncertainty (e.g. std dev) measured
   double threshold;     //!< Uncertainty value below which trigger is satisfied
+  bool allow_zero;      //!< Whether to allow zero tally bins to be ignored
   int score_index;      //!< Index of the relevant score in the tally's arrays
 };
 

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -689,6 +689,12 @@ void Tally::init_triggers(pugi::xml_node node)
         "Must specify trigger threshold for tally {} in tally XML file", id_));
     }
 
+    // Read whether to allow zero-tally bins to be ignored.
+    bool allow_zero = false;
+    if (check_for_node(trigger_node, "allow_zero")) {
+      allow_zero = get_node_value_bool(trigger_node, "allow_zero");
+    }
+
     // Read the trigger scores.
     vector<std::string> trigger_scores;
     if (check_for_node(trigger_node, "scores")) {
@@ -702,7 +708,7 @@ void Tally::init_triggers(pugi::xml_node node)
       if (score_str == "all") {
         triggers_.reserve(triggers_.size() + this->scores_.size());
         for (auto i_score = 0; i_score < this->scores_.size(); ++i_score) {
-          triggers_.push_back({metric, threshold, i_score});
+          triggers_.push_back({metric, threshold, allow_zero, i_score});
         }
       } else {
         int i_score = 0;
@@ -716,7 +722,7 @@ void Tally::init_triggers(pugi::xml_node node)
                         "{} but it was listed in a trigger on that tally",
               score_str, id_));
         }
-        triggers_.push_back({metric, threshold, i_score});
+        triggers_.push_back({metric, threshold, allow_zero, i_score});
       }
     }
   }

--- a/src/tallies/trigger.cpp
+++ b/src/tallies/trigger.cpp
@@ -77,9 +77,9 @@ void check_tally_triggers(double& ratio, int& tally_id, int& score)
         auto uncert_pair =
           get_tally_uncertainty(i_tally, trigger.score_index, filter_index);
 
-        // if there is a score without contributions, set ratio to inf and
-        // exit early
-        if (uncert_pair.first == -1) {
+        // If there is a score without contributions, set ratio to inf and
+        // exit early, unless zero score is allowed for this trigger.
+        if (uncert_pair.first == -1 && ! trigger.allow_zero) {
           ratio = INFINITY;
           score = t.scores_[trigger.score_index];
           tally_id = t.id_;

--- a/src/tallies/trigger.cpp
+++ b/src/tallies/trigger.cpp
@@ -167,7 +167,7 @@ void check_triggers()
   // See if the current batch is one for which the triggers must be checked.
   if (!settings::trigger_on)
     return;
-  if (current_batch < n_batches)
+  if (current_batch <= n_batches)
     return;
   if (((current_batch - n_batches) % interval) != 0)
     return;

--- a/src/tallies/trigger.cpp
+++ b/src/tallies/trigger.cpp
@@ -79,7 +79,7 @@ void check_tally_triggers(double& ratio, int& tally_id, int& score)
 
         // If there is a score without contributions, set ratio to inf and
         // exit early, unless zero score is allowed for this trigger.
-        if (uncert_pair.first == -1 && ! trigger.allow_zero) {
+        if (uncert_pair.first == -1 && !trigger.allow_zero) {
           ratio = INFINITY;
           score = t.scores_[trigger.score_index];
           tally_id = t.id_;

--- a/tests/unit_tests/test_triggers.py
+++ b/tests/unit_tests/test_triggers.py
@@ -73,3 +73,42 @@ def test_tally_trigger_null_score(run_in_tmpdir):
         total_batches = sp.n_realizations + sp.n_inactive
         assert total_batches == pincell.settings.trigger_max_batches
 
+
+def test_tally_trigger_zero_allowed(run_in_tmpdir):
+    pincell = openmc.examples.pwr_pin_cell()
+ 
+    # create an energy filter below and around the O-16(n,p) threshold
+    e_filter = openmc.EnergyFilter([0.0, 1e7, 2e7])
+
+    # create a tally with triggers applied
+    tally = openmc.Tally()
+    tally.filters = [e_filter]
+    tally.scores = ['(n,p)']
+    tally.nuclides = ["O16"]
+
+    # 100% relative error: should be immediately satisfied in nonzero bin
+    trigger = openmc.Trigger('rel_err', 1.0)
+    trigger.scores = ['(n,p)']
+    trigger.allow_zero = True
+
+    tally.triggers = [trigger]
+
+    pincell.tallies = [tally]
+
+    pincell.settings.trigger_active = True
+    pincell.settings.trigger_max_batches = 50
+    pincell.settings.trigger_batch_interval = 20
+
+    sp_file = pincell.run()
+
+    with openmc.StatePoint(sp_file) as sp:
+        # verify that the first bin is zero and the second is nonzero
+        tally_out = sp.get_tally(id=tally.id)
+        below, above = tally_out.mean.squeeze()
+        assert below == 0.0, "Tally events observed below expected threshold"
+        assert above > 0, "No tally events observed. Test with more particles."
+
+        # we expect that the trigger fires before max batches are hit
+        total_batches = sp.n_realizations + sp.n_inactive
+        assert total_batches < pincell.settings.trigger_max_batches
+


### PR DESCRIPTION
Resolve https://github.com/openmc-dev/openmc/issues/2899 


# Description

Add the ability to ignore tally bins with zero scores when evaluating tally triggers.

 * New `allow_zero` option for `Trigger` class and _tallies.xml_. (default: False)
 * If there is a score without contributions, do not set the trigger threshold ratio to infinity if the trigger allows zero scores.
 * Ensure that a full trigger batch interval is run before evaluating triggers (see below).
 * Add a unit test. The O-16(n,p) reaction is tallied using an energy filter with two bins, one of which is entirely below the threshold energy. The low energy bin should always have a score of zero.
 * Update "Tallies Specification" documentation.
 
There is some behavior in OpenMC I did not expect, where tally triggers are checked shortly after the completion of inactive batches without necessarily running a full trigger batch interval. I think it is necessary to change that current behavior to run a full interval first. Else, tally triggers for rare events (where they are needed most!) will fire prematurely if there are no hits at this initial check.


Fixes #2899 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->

# Questions

 - Do we want to change OpenMC's tally trigger behavior? https://github.com/aprilnovak/openmc/pull/3/commits/a1da1534f72c0250832b2b2264a76357b8431253
 - Should there be a setting to only include (or exclude) certain bins from the `allow_zero` option to the tally trigger? I do not think so, given that triggers themselves do not have a setting for particular bins.
 - Should a regression test be added, or is the single unit test sufficient? 
 - Is there a cleaner way to load str->bool from the XML without using `eval` (unsafe) or `distutils` (deprecated)?